### PR TITLE
Added deployment, updated image name for quick deployment

### DIFF
--- a/deploy/destalinator-deployment.yml
+++ b/deploy/destalinator-deployment.yml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: destalinator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: destalinator
+        tier: backend
+    spec:
+      containers:
+      - name: destalinator
+        image: thornycrackers/destalinator
+        env:
+        - name: DESTALINATOR_SB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: destalinator-secret
+              key: destalinator-sb-token
+        - name: DESTALINATOR_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: destalinator-secret
+              key: destalinator-api-token
+        - name: DESTALINATOR_RUN_ONCE
+          value: 'true'
+        - name: DESTALINATOR_ACTIVATED
+          value: 'false'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
     network_mode: "bridge"
     container_name: destalinator
-    image: devedmonton/destalinator
+    image: thornycrackers/destalinator
     ports:
       - "8000"
     volumes:


### PR DESCRIPTION
@ashiazed I had to change the name of the image so that I could push to dockerhub and the k8s cluster could pull the image. These changes can be accepted and then devedmonton will have to:

- Create an image repository for this repo
- Change the image name
- Deploy on the new image